### PR TITLE
fix for swagger without operationIds

### DIFF
--- a/lib/commands/generateApi/generateProxyEndPoint.js
+++ b/lib/commands/generateApi/generateProxyEndPoint.js
@@ -23,6 +23,7 @@ module.exports = function generateProxyEndPoint(apiProxy, options, api, cb) {
     for (var resource in api.paths[apiPath]) {
       if (allowedVerbs.indexOf(resource.toUpperCase()) >= 0) {
         var resourceItem = api.paths[apiPath][resource];
+        resourceItem.operationId = resourceItem.operationId || resource.toUpperCase() + ' ' + apiPath;
         var flow = flows.ele('Flow', {name: resourceItem.operationId});
         var flowCondition = '(proxy.pathsuffix MatchesPath &quot;' + apiPath + '&quot;) and (request.verb = &quot;' + resource.toUpperCase() + '&quot;)';
         flow.ele('Condition').raw(flowCondition);


### PR DESCRIPTION
creates flows with name "METHOD path" if operationId is null.
