### PR TITLE
fix for -v flag

### DIFF
--- a/lib/commands/generateApi/generateProxyEndPoint.js
+++ b/lib/commands/generateApi/generateProxyEndPoint.js
@@ -73,8 +73,10 @@ module.exports = function generateProxyEndPoint(apiProxy, options, api, cb) {
 
   var httpProxyConn = root.ele('HTTPProxyConnection');
   httpProxyConn.ele('BasePath', {}, "/" + apiProxy);
-  httpProxyConn.ele('VirtualHost', {}, 'default');
-  httpProxyConn.ele('VirtualHost', {}, 'secure');
+  var virtualhosts = (options.virtualhosts) ? options.virtualhosts.split(',') : ['default','secure'];
+  virtualhosts.forEach(function (virtualhost) {
+    httpProxyConn.ele('VirtualHost', {}, virtualhost);
+  });
 
   var routeRule = root.ele('RouteRule', {name: "default"});
   routeRule.ele('TargetEndpoint', {}, 'default');


### PR DESCRIPTION
Hi Anil,

this pr contains a fix for the -v flag:

-v 'secure' generates

```
  <HTTPProxyConnection>
    <VirtualHost>secure</VirtualHost>
  </HTTPProxyConnection>

```

-v 'default' generates

```
  <HTTPProxyConnection>
    <VirtualHost>default</VirtualHost>
  </HTTPProxyConnection>

```

-v 'secure,default' generates

```
  <HTTPProxyConnection>
    <VirtualHost>secure</VirtualHost>
    <VirtualHost>default</VirtualHost>
  </HTTPProxyConnection>

```
