### PR TITLE
Updating Swagger specification references to OpenAPI references

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Anil Sagar
+Copyright (c) 2016 Apigee Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You can install `openapi2apigee` either through npm or by cloning and linking th
 
 ## Installation from npm
 
-The `openapi2apigee` module and its dependencies are designed for Node.js and is available through npm using the following command:
+The `openapi2apigee` module (and its dependencies) is designed for Node.js and is available through npm using the following command:
 
 ### From a Terminal Window:
 ```bash
@@ -34,7 +34,7 @@ $ openapi2apigee generateApi petStore -s http://petstore.openapi.io/v2/openapi.j
 
 <a href="https://community.apigee.com/articles/9478/openapi2apigee-020-version-generating-apigee-policies.html">openapi2apigee Apigee-127 Extensions support</a>
 
-<a href="https://community.apigee.com/articles/9741/openapi2apigee-021-version-securing-apis-using-swagge.html"> Secure APIs using OAuth 2.0 & Verify API Key Policies in Apigee using OpenAPI 2.0</a>
+<a href="https://community.apigee.com/articles/9741/openapi2apigee-021-version-securing-apis-using-oas.html"> Secure APIs using OAuth 2.0 & Verify API Key Policies in Apigee using OpenAPI 2.0</a>
 
 #### Docker Image
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# swagger-apigee-node-utility
-Swagger to Apigee API Proxy using Node.js Utility
+# openapi-apigee-node-utility
+OpenAPI (formerly known as Swagger) to Apigee API Proxy Bundle using Node.js Utility
 
 # Installation
 
-You can install `swagger2api` either through npm or by cloning and linking the code from GitHub.  This document covers the installation details for installing from npm.
+You can install `openapi2apigee` either through npm or by cloning and linking the code from GitHub.  This document covers the installation details for installing from npm.
 
 ## Installation from npm
 
-The `swagger2api` module and its dependencies are designed for Node.js and is available through npm using the following command:
+The `openapi2apigee` module and its dependencies are designed for Node.js and is available through npm using the following command:
 
 ### From a Terminal Window:
 ```bash
-$ sudo npm install -g swagger2api
+$ sudo npm install -g openapi2apigee
 ```
 
 # <a name="reference"></a>Command reference and examples
@@ -20,24 +20,22 @@ $ sudo npm install -g swagger2api
 
 ## <a name="generateapi"></a>generateApi
 
-Generates Apigee API Bundles from Swagger files and help you deploy to Apigee Edge
+Generates Apigee API Bundles from OpenAPI files and help you deploy to Apigee Edge
 
 #### Examples
 
 ```bash
-$ swagger2api generateApi petStore -s http://petstore.swagger.io/v2/swagger.json -D -d /Users/Anil/Desktop/
+$ openapi2apigee generateApi petStore -s http://petstore.openapi.io/v2/openapi.json -D -d /Users/Anil/Desktop/
 ```
 
 #### Articles
 
-<a href="https://community.apigee.com/articles/8796/swagger2api-a-nodejs-command-line-tool-to-generate.html">Getting Started with Swagger2API</a>
+<a href="https://community.apigee.com/articles/8796/openapi2apigee-a-nodejs-command-line-tool-to-generate.html">Getting Started with OpenAPI</a>
 
-<a href="https://community.apigee.com/articles/9478/swagger2api-020-version-generating-apigee-policies.html">Swagger2API Apigee-127 Extensions support</a>
+<a href="https://community.apigee.com/articles/9478/openapi2apigee-020-version-generating-apigee-policies.html">openapi2apigee Apigee-127 Extensions support</a>
 
-<a href="https://community.apigee.com/articles/9741/swagger2api-021-version-securing-apis-using-swagge.html"> Secure APIs using OAuth2.0 & Verify API Key Policies in Apigee using Swagger 2.0</a>
+<a href="https://community.apigee.com/articles/9741/openapi2apigee-021-version-securing-apis-using-swagge.html"> Secure APIs using OAuth 2.0 & Verify API Key Policies in Apigee using OpenAPI 2.0</a>
 
 #### Docker Image
 
 <a href="https://hub.docker.com/r/murf/apigee-swagger2api/">Docker Image</a> By Mikael Mellgren
-
-

--- a/bin/openapi2apigee
+++ b/bin/openapi2apigee
@@ -15,7 +15,7 @@ program
 program
   .usage('<command> <options>')
   .command('generateApi <apiProxy>')
-  .option('-s, --source <source>', 'Swagger File Source.')
+  .option('-s, --source <source>', 'openapi File Source.')
   .option('-d, --destination <destination>', 'API Bundle destination location.')
   .option('-D, --deploy', 'Deploy to Apigee Edge')
   .option('-b, --baseuri <baseuri>', 'Apigee Edge EndPoint to Deploy')
@@ -56,8 +56,8 @@ program
 program.on('--help', function(){
   console.log('  Examples:');
   console.log('');
-  console.log('    $ swagger2api generateApi --help');
-  console.log('    $ swagger2api generateApi -s http://petstore.swagger.io/v2/swagger.json -d /Users/Anil/Desktop/ -D petStore');
+  console.log('    $ openapi2apigee generateApi --help');
+  console.log('    $ openapi2apigee generateApi -s http://petstore.openapi.io/v2/openapi.json -d /Users/Anil/Desktop/ -D petStore');
   console.log('');
 });
 

--- a/lib/commands/generateApi/generateApi.js
+++ b/lib/commands/generateApi/generateApi.js
@@ -1,4 +1,4 @@
-var parser = require("swagger-parser");
+var parser = require("openapi-parser");
 var generateSkeleton = require('./generateSkeleton.js');
 var generateProxy = require('./generateProxy.js');
 var generatePolicies = require('./generatePolicies.js');
@@ -68,7 +68,7 @@ function generateApi(apiProxy, options, cb) {
       });
     }
     else {
-      return cb(err, { error: 'Swagger parsing failed..'});
+      return cb(err, { error: 'openapi parsing failed..'});
     }
   });
 }

--- a/lib/commands/generateApi/generateApi.js
+++ b/lib/commands/generateApi/generateApi.js
@@ -1,4 +1,4 @@
-var parser = require("openapi-parser");
+var parser = require("swagger-parser");
 var generateSkeleton = require('./generateSkeleton.js');
 var generateProxy = require('./generateProxy.js');
 var generatePolicies = require('./generatePolicies.js');

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
-  "name": "swagger2api",
+  "name": "openapi2apigee",
   "version": "0.3.0",
-  "description": "A tool that converts swagger yaml file to Apigee API Proxy Bundle",
+  "description": "A tool that converts openapi yaml file to Apigee API Proxy Bundle",
   "main": "index.js",
   "scripts": {
     "test": "make test",
     "coverage": "istanbul cover _mocha -- test/util test/commands -R spec"
   },
   "bin": {
-    "swagger2api": "bin/swagger2api"
+    "openapi2apigee": "bin/openapi2apigee"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/anil614sagar/swagger-apigee-node-utility.git"
+    "url": "https://github.com/anil614sagar/openapi-apigee-node-utility.git"
   },
   "keywords": [
     "Apigee",
-    "Swagger",
+    "openapi",
     "Tool",
     "Api",
     "Proxy"
@@ -24,9 +24,9 @@
   "author": "Anil Sagar <anil614sagar@gmail.com> (https://in.linkedin.com/in/anilsagar/)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/anil614sagar/swagger-apigee-node-utility/issues"
+    "url": "https://github.com/anil614sagar/openapi-apigee-node-utility/issues"
   },
-  "homepage": "https://github.com/anil614sagar/swagger-apigee-node-utility",
+  "homepage": "https://github.com/anil614sagar/openapi-apigee-node-utility",
   "dependencies": {
     "apigeetool": "^0.5.4",
     "archiver": "^0.14.4",
@@ -35,7 +35,7 @@
     "easy-zip": "0.0.4",
     "inquirer": "^0.9.0",
     "mkdirp": "^0.5.1",
-    "swagger-parser": "^2.5.0",
+    "openapi-parser": "^2.5.0",
     "xmlbuilder": "^2.6.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   },
   "keywords": [
     "Apigee",
-    "openapi",
+    "OpenAPI",
+    "Swagger",
     "Tool",
-    "Api",
-    "Proxy"
+    "API",
+    "Proxy",
+    "Proxies"
   ],
   "author": "Anil Sagar <anil614sagar@gmail.com> (https://in.linkedin.com/in/anilsagar/)",
   "license": "MIT",
@@ -35,7 +37,7 @@
     "easy-zip": "0.0.4",
     "inquirer": "^0.9.0",
     "mkdirp": "^0.5.1",
-    "openapi-parser": "^2.5.0",
+    "swagger-parser": "^2.5.0",
     "xmlbuilder": "^2.6.4"
   },
   "devDependencies": {

--- a/test/commands/generateApi.js
+++ b/test/commands/generateApi.js
@@ -9,20 +9,20 @@ var fs = require('fs');
 
 describe('generateApi', function() {
   describe('generate', function() {
-    it('Incorrect swagger file should generate error..', function(done) {
+    it('Incorrect openapi file should generate error..', function(done) {
       var options = {
-        source : path.join(__dirname, '/swagger_files/swagger2.yaml'),
+        source : path.join(__dirname, '/openapi_files/openapi2.yaml'),
         destination : path.join(__dirname, '../../api_bundles'),
       }
       generateApi.generateApi('petStore', options, function(err, reply) {
         should.notEqual(err, null);
-        reply.error.should.eql('Swagger parsing failed..');
+        reply.error.should.eql('openapi parsing failed..');
         done();
       })
     });
-    it('Correct swagger file should not generate error..', function(done) {
+    it('Correct openapi file should not generate error..', function(done) {
       var options = {
-        source : path.join(__dirname, '/swagger_files/swagger1.yaml'),
+        source : path.join(__dirname, '/openapi_files/openapi1.yaml'),
         destination : path.join(__dirname, '../../api_bundles'),
       }
       generateApi.generateApi('petStore', options, function(err, reply) {
@@ -53,7 +53,7 @@ describe('generateApi', function() {
   describe('generateSkeleton', function() {
     it('generate Skeleton should create folder structure', function(done) {
       var options = {
-        source : path.join(__dirname, '/swagger_files/swagger1.yaml'),
+        source : path.join(__dirname, '/openapi_files/openapi1.yaml'),
         destination : path.join(__dirname, '../../api_bundles'),
         apiProxy : randomText()
       }
@@ -72,7 +72,7 @@ describe('generateApi', function() {
     });
     it('destination path ending with / should generate Skeleton Folder', function(done) {
       var options = {
-        source : path.join(__dirname, '/swagger_files/swagger1.yaml'),
+        source : path.join(__dirname, '/openapi_files/openapi1.yaml'),
         destination : path.join(__dirname, '../../api_bundles/'),
         apiProxy : randomText()
       }

--- a/test/commands/generateApiCors.js
+++ b/test/commands/generateApiCors.js
@@ -10,7 +10,7 @@ var xml2js = require('xml2js');
 
 describe('generateApi with CORS proxy', function() {
   var options = {
-    source : path.join(__dirname, '/swagger_files/cors.yaml'),
+    source : path.join(__dirname, '/openapi_files/cors.yaml'),
     destination : path.join(__dirname, '../../api_bundles'),
     apiProxy :'petStoreCors'
   };
@@ -19,9 +19,9 @@ describe('generateApi with CORS proxy', function() {
   rimraf.sync(bundle);
 
   describe('generate', function() {
-    it('Correct swagger file should generate proxy', function(done) {
+    it('Correct openapi file should generate proxy', function(done) {
       var options = {
-        source : path.join(__dirname, '/swagger_files/cors.yaml'),
+        source : path.join(__dirname, '/openapi_files/cors.yaml'),
         destination : path.join(__dirname, '../../api_bundles'),
         apiProxy :'petStoreCors'
       }

--- a/test/commands/openapi_files/cors.yaml
+++ b/test/commands/openapi_files/cors.yaml
@@ -1,10 +1,10 @@
-swagger: "2.0"
+openapi: "2.0"
 info:
   version: 1.0.0
-  title: Swagger Petstore
+  title: openapi Petstore Cors
   license:
     name: MIT
-host: petstore.swagger.io
+host: petstore.openapi.io
 basePath: /v1
 schemes:
   - http
@@ -13,6 +13,46 @@ consumes:
 produces:
   - application/json
 x-a127-services:
+  add-cors:
+    provider: x-cors
+    options:
+      displayName: Add CORS
+      headers:
+        Access-Control-Allow-Origin:
+          type: string
+          default: "*"
+          description: >
+            Setting this header to `*` allows all origins.
+            This is handy for public REST APIs that don't require
+            authentication. But, according to the HTTP spec, browsers
+            *WILL NOT* send cookies if this header is `*`, regardless
+            of what you set `Access-Control-Allow-Credentials` to.
+        Access-Control-Allow-Credentials:
+          type: boolean
+          default: false
+          description: >
+            Setting this header to `false` means that your API does not
+            use authentication cookies.
+        Access-Control-Allow-Headers:
+          type: array
+          collectionFormat: csv
+          default: origin, x-requested-with, accept
+          description: >
+            This shows how you can explicitly specify which HTTP headers
+            your API allows.
+        Access-Control-Allow-Methods:
+          type: array
+          collectionFormat: csv
+          default: GET, PUT, POST, DELETE
+          description: >
+            This shows how you can explicitly specify which HTTP methods
+            your API allows.
+        Access-Control-Max-Age:
+          type: integer
+          default: 3628800
+          description: >
+            This allows client browsers to cache the CORS response for
+            one day (3628800 seconds).
   quotaAnil:
     provider: volos-quota-memory
     options:

--- a/test/commands/openapi_files/openapi1.yaml
+++ b/test/commands/openapi_files/openapi1.yaml
@@ -1,10 +1,10 @@
-swagger: "2.0"
+openapi: "2.0"
 info:
   version: 1.0.0
-  title: Swagger Petstore Cors
+  title: openapi Petstore
   license:
     name: MIT
-host: petstore.swagger.io
+host: petstore.openapi.io
 basePath: /v1
 schemes:
   - http
@@ -13,46 +13,6 @@ consumes:
 produces:
   - application/json
 x-a127-services:
-  add-cors:
-    provider: x-cors
-    options:
-      displayName: Add CORS
-      headers:
-        Access-Control-Allow-Origin:
-          type: string
-          default: "*"
-          description: >
-            Setting this header to `*` allows all origins.
-            This is handy for public REST APIs that don't require
-            authentication. But, according to the HTTP spec, browsers
-            *WILL NOT* send cookies if this header is `*`, regardless
-            of what you set `Access-Control-Allow-Credentials` to.
-        Access-Control-Allow-Credentials:
-          type: boolean
-          default: false
-          description: >
-            Setting this header to `false` means that your API does not
-            use authentication cookies.
-        Access-Control-Allow-Headers:
-          type: array
-          collectionFormat: csv
-          default: origin, x-requested-with, accept
-          description: >
-            This shows how you can explicitly specify which HTTP headers
-            your API allows.
-        Access-Control-Allow-Methods:
-          type: array
-          collectionFormat: csv
-          default: GET, PUT, POST, DELETE
-          description: >
-            This shows how you can explicitly specify which HTTP methods
-            your API allows.
-        Access-Control-Max-Age:
-          type: integer
-          default: 3628800
-          description: >
-            This allows client browsers to cache the CORS response for
-            one day (3628800 seconds).
   quotaAnil:
     provider: volos-quota-memory
     options:

--- a/test/commands/openapi_files/openapi2.yaml
+++ b/test/commands/openapi_files/openapi2.yaml
@@ -1,8 +1,8 @@
-swagger: "2.0"
+openapi: "2.0"
 info:
   version: 1.0.0
-  title: Swagger Petstore
-  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  title: openapi Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the openapi-2.0 specification
   termsOfService: http://helloreverb.com/terms/
   contact:
     name: Wordnik API Team
@@ -11,7 +11,7 @@ info:
   license:
     name: MIT
     url: http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
-host: petstore.swagger.wordnik.com
+host: petstore.openapi.wordnik.com
 basePath: /api
 consumes:
   - application/json


### PR DESCRIPTION
Note in addition to updating the references to the description format formerly-known-as-Swagger to the new name `OpenAPI`, this PR also:
1. Changes the name of the command itself to `openapi2apigee`
2. Notes the history of the specification name change in the readme
3. Changes the copyright assignment

Things that might still need to be addressed outside this PR:
1. The project should be renamed to reflect the new command name `openapi2apigee`
2. The npm module name will need updating
3. The related Docker image linked in the Readme might want to update.
