### PR TITLE
BasePath fix

### DIFF
--- a/lib/commands/generateApi/generateProxyEndPoint.js
+++ b/lib/commands/generateApi/generateProxyEndPoint.js
@@ -178,7 +178,7 @@ module.exports = function generateProxyEndPoint(apiProxy, options, api, cb) {
 
 
   var httpProxyConn = root.ele('HTTPProxyConnection');
-  httpProxyConn.ele('BasePath', {}, "/" + apiProxy);
+  httpProxyConn.ele('BasePath', {}, "/" + api.basePath);
   var virtualhosts = (options.virtualhosts) ? options.virtualhosts.split(',') : ['default','secure'];
   virtualhosts.forEach(function (virtualhost) {
     httpProxyConn.ele('VirtualHost', {}, virtualhost);


### PR DESCRIPTION
With this fix basePath in the proxy endpoint will have the base-path defined in the openAPIspec instead of the proxy name.