### PR TITLE
if basepath is not defined in OAS, "undefined" string is used

### DIFF
--- a/lib/commands/generateApi/generateTargetEndPoint.js
+++ b/lib/commands/generateApi/generateTargetEndPoint.js
@@ -38,7 +38,9 @@ module.exports = function generateTargetEndPoint (apiProxy, options, api, cb) {
   postFlow.ele('Response')
 
   var httpTargetConn = root.ele('HTTPTargetConnection')
-  httpTargetConn.ele('URL', {}, api.schemes[0] + '://' + api.host + api.basePath)
+  httpTargetConn.ele('URL', {}, api.schemes[0] + '://' + api.host + 
+    ((!!api.basePath)?api.basePath:"")
+  );
 
   var xmlString = root.end({ pretty: true, indent: '  ', newline: '\n' })
   fs.writeFile(rootDirectory + '/targets/default.xml', xmlString, function (err) {


### PR DESCRIPTION
test if basepath is undefined.  If defined, use supplied basepath.  If not defined, use an empty string.