### PR TITLE
Adding -B basepath option for proxy basepath

### DIFF
--- a/bin/openapi2apigee
+++ b/bin/openapi2apigee
@@ -19,6 +19,7 @@ program
   .option('-d, --destination <destination>', 'API Bundle destination location.')
   .option('-D, --deploy', 'Deploy to Apigee Edge')
   .option('-b, --baseuri <baseuri>', 'Apigee Edge EndPoint to Deploy')
+  .option('-B, --basepath <basepath>', 'Apigee Edge BasePath to Deploy')
   .option('-o, --organization <organization>', 'Apigee Edge Organization to Deploy')
   .option('-e, --environments <environments>', 'Apigee Edge Environment to Deploy')
   .option('-v, --virtualhosts <virtualhosts>', 'Apigee Edge virtual hosts to Deploy')

--- a/lib/commands/generateApi/generateProxyEndPoint.js
+++ b/lib/commands/generateApi/generateProxyEndPoint.js
@@ -182,7 +182,9 @@ module.exports = function generateProxyEndPoint (apiProxy, options, api, cb) {
   }
 
   var httpProxyConn = root.ele('HTTPProxyConnection')
-  if (api.basePath !== undefined) {
+  if (options.basepath) {
+    httpProxyConn.ele('BasePath', {}, options.basepath)
+  } else if (api.basePath !== undefined) {
     httpProxyConn.ele('BasePath', {}, api.basePath)
   } else {
     httpProxyConn.ele('BasePath', {}, '/' + apiProxy)


### PR DESCRIPTION
https://github.com/anil614sagar/openapi2apigee/issues/7

By Adding -B or --basepath, a different basepath can be passed to the proxy, 
IE: <proxy_url>/proxybasepath ---> <target_url>/api/v1 

